### PR TITLE
test when dependent class does not exist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         beStrictAboutChangesToGlobalState="true"
-         beStrictAboutOutputDuringTests="true"
-         colors="true"
-         cacheDirectory=".phpunit.cache"
-         cacheResult="false"
-         executionOrder="random"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <ini name="memory_limit" value="-1"/>
-        <ini name="error_reporting" value="-1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" colors="true" cacheDirectory=".phpunit.cache" cacheResult="false" executionOrder="random">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
+  <php>
+    <ini name="memory_limit" value="-1"/>
+    <ini name="error_reporting" value="-1"/>
+  </php>
 </phpunit>

--- a/tests/Fakes/InstantiableWithParametersDoNotExist.php
+++ b/tests/Fakes/InstantiableWithParametersDoNotExist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MtsDependencyInjection\Tests\Fakes;
+
+/**
+ * @psalm-suppress UndefinedClass
+ * @psalm-suppress UnusedProperty
+ */
+class InstantiableWithParametersDoNotExist
+{
+    /**
+     * This class requires a property from a class that does not exist.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function __construct(private readonly DoesNotExist $doesNotExist)
+    {
+    }
+}

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -13,6 +13,7 @@ use MtsDependencyInjection\Tests\Fakes\InstantiableWithInterface;
 use MtsDependencyInjection\Tests\Fakes\InstantiableWithoutParameters;
 use MtsDependencyInjection\Tests\Fakes\InstantiableWithoutParametersAgain;
 use MtsDependencyInjection\Tests\Fakes\InstantiableWithParameters;
+use MtsDependencyInjection\Tests\Fakes\InstantiableWithParametersDoNotExist;
 use MtsDependencyInjection\Tests\Fakes\Uninstantiable;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -387,5 +388,18 @@ final class ContainerTest extends TestCase
                 'null' => false,
             ],
         ];
+    }
+
+    /**
+     * @throws \MtsDependencyInjection\Exceptions\ContainerException
+     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
+     * @throws \ReflectionException
+     */
+    public function testClassDoesNotExist(): void
+    {
+        $this->expectException(\ArgumentCountError::class);
+
+        $this->fixture->set('undefinedClass', InstantiableWithParametersDoNotExist::class);
+        $this->fixture->get('undefinedClass');
     }
 }


### PR DESCRIPTION
This tests for when a dependent class does not exist when trying to get an object.

I ran the `vendor/bin/phpunit --migrate-configuration` command to update the PHPUnit XML file. With that, I added the `coverage` tag with the source directory. Without the source directory in the configuration file, PhpStorm was unable to know for what to generate code coverage.